### PR TITLE
added a script to copy initial storage settings into volume

### DIFF
--- a/docker_only/Dockerfile
+++ b/docker_only/Dockerfile
@@ -44,7 +44,11 @@ RUN chown -R www-data /opt/graphite/storage
 RUN chmod 0775 /opt/graphite/storage /opt/graphite/storage/whisper
 RUN chmod 0664 /opt/graphite/storage/graphite.db
 RUN cd /opt/graphite/webapp/graphite && python manage.py syncdb --noinput
-VOLUME  /opt/graphite
+
+ADD ./copy_storage.sh /opt/graphite/bin/copy_storage.sh
+RUN chmod a+x /opt/graphite/bin/copy_storage.sh
+
+RUN mv /opt/graphite/storage /opt/graphite/storage.bak
 
 RUN mkdir -p /opt/statsd
 WORKDIR /opt/statsd

--- a/docker_only/Makefile
+++ b/docker_only/Makefile
@@ -4,10 +4,10 @@ build:
 	docker build -t statsd .
 
 run:
-	docker run --name statsd -p 80:80 -p 2003:2003 -p 2004:2004 -p 7002:7002 -p 8125:8125/udp -p 8126:8126 -v /var/log/supervisor:/var/log/supervisor -d statsd
+	docker run --name statsd -p 80:80 -p 2003:2003 -p 2004:2004 -p 7002:7002 -p 8125:8125/udp -p 8126:8126 -v /var/log/supervisor:/var/log/supervisor -v /opt/graphite/storage:/opt/graphite/storage -d statsd
 
 debug: 
-	docker run --name statsd -i -p 80:80 -p 2003:2003 -p 2004:2004 -p 7002:7002 -p 8125:8125/udp -p 8126:8126 -v /var/log/supervisor:/var/log/supervisor statsd
+	docker run --name statsd -i -p 80:80 -p 2003:2003 -p 2004:2004 -p 7002:7002 -p 8125:8125/udp -p 8126:8126 -v /var/log/supervisor:/var/log/supervisor -v /opt/graphite/storage:/opt/graphite/storage statsd
 
 ping:
 	nc -z -w5 127.0.0.1 8125; echo $?

--- a/docker_only/config.js
+++ b/docker_only/config.js
@@ -5,5 +5,6 @@
   flushInterval: 10000,
   debug: false,
   dumpMessages: false,
-  backends: ["./backends/graphite"]
+  backends: ["./backends/graphite"],
+  deleteIdleStats: true
 }

--- a/docker_only/configs/supervisord.conf
+++ b/docker_only/configs/supervisord.conf
@@ -2,6 +2,13 @@
 nodaemon = true
 environment = GRAPHITE_STORAGE_DIR='/opt/graphite/storage',GRAPHITE_CONF_DIR='/opt/graphite/conf'
 
+[program:copy_storage]
+priority = 1
+command = /opt/graphite/bin/copy_storage.sh
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+startsecs = 0
+
 [program:nginx]
 command = /usr/sbin/nginx
 stdout_logfile = /var/log/supervisor/%(program_name)s.log

--- a/docker_only/copy_storage.sh
+++ b/docker_only/copy_storage.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -x
+
+if [ ! -d /opt/graphite/storage/whisper ]
+then
+    cp -r /opt/graphite/storage.bak/* /opt/graphite/storage/
+    chown -R www-data /opt/graphite/storage
+fi
+


### PR DESCRIPTION
in order to persist /opt/graphite/storage between container restarts, we need to take steps to 
1. setup default /opt/graphite/storage settings files etc (pip adds a bunch of stuff)
2. backup to /opt/graphite/storage.bak
3. allow docker to create the data volume  /opt/graphite/storage on the host 
4. copy the initial files back, if they don't exist already
