### PR TITLE
use different var from django hashing secret key

### DIFF
--- a/docker_only/README.md
+++ b/docker_only/README.md
@@ -2,4 +2,4 @@
 
 Prior to running the built graphite container, execute the following command, replacing `your-secret-key!`
 
-    sudo mkdir -m 777 /local_auth && sudo echo "SECRET_KEY='your-secret-key!'" > /local_auth/__init__.py
+    sudo mkdir -m 777 /local_auth && sudo echo "ENDPOINT_SECRET_KEY='your-secret-key!'" > /local_auth/__init__.py

--- a/docker_only/configs/local_settings.py
+++ b/docker_only/configs/local_settings.py
@@ -14,9 +14,9 @@
 # instances if used behind a load balancer.
 
 try:
-    from graphite.local_auth import SECRET_KEY
+    from graphite.local_auth import ENDPOINT_SECRET_KEY
 except ImportError:
-    SECRET_KEY = 'UNSAFE_DEFAULT'
+    ENDPOINT_SECRET_KEY = 'UNSECURED_ENDPOINT'
 
 # Set your local timezone (Django's default is America/Chicago)
 # If your graphs appear to be offset by a couple hours then this probably
@@ -40,9 +40,9 @@ from graphite.app_settings import *
 
 class SecretKeyMiddleware(object):
     def process_request(self, request):
-        if (SECRET_KEY == 'UNSAFE_DEFAULT'
-                or request.GET.get('secret') == SECRET_KEY
-                or request.POST.get('secret') == SECRET_KEY):
+        if (ENDPOINT_SECRET_KEY == 'UNSECURED_ENDPOINT'
+                or request.GET.get('secret') == ENDPOINT_SECRET_KEY
+                or request.POST.get('secret') == ENDPOINT_SECRET_KEY):
             return None
 
         from django.http import HttpResponse


### PR DESCRIPTION
Use a different variable to keep track of the secret key used for auth
against the SecretKeyMiddleware than the SECRET_KEY used as salt by
django in hashing so that the auth secret key can be easily changed
without affecting data locations etc.

@shawnrusaw-wf @lyddonb 
